### PR TITLE
Fix lock issue training bert

### DIFF
--- a/p2pfl/communication/commands/weights/full_model_command.py
+++ b/p2pfl/communication/commands/weights/full_model_command.py
@@ -64,17 +64,12 @@ class FullModelCommand(Command):
                 )
                 return
 
-            # Check moment
-            if not self.state.wait_aggregated_model_lock.locked():
-                logger.debug(self.state.addr, "😲 Aggregated model not expected.")
-                return
-
             try:
                 logger.info(self.state.addr, "📦 Aggregated model received.")
                 # Decode and set model
                 self.learner.set_model(weights)
-                # Release lock
-                self.state.wait_aggregated_model_lock.release()
+                # Release here caused the simulation to crash before
+                self.state.wait_aggregated_model_event.set()
 
             # Warning: these stops can cause a denegation of service attack
             except DecodingParamsError:

--- a/p2pfl/communication/commands/weights/full_model_command.py
+++ b/p2pfl/communication/commands/weights/full_model_command.py
@@ -63,13 +63,15 @@ class FullModelCommand(Command):
                     f"Model reception in a late round ({round} != {self.state.round}).",
                 )
                 return
-
+            if self.state.aggregated_model_event.is_set():
+                logger.debug(self.state.addr, "😲 Aggregated model not expected.")
+                return
             try:
                 logger.info(self.state.addr, "📦 Aggregated model received.")
                 # Decode and set model
                 self.learner.set_model(weights)
                 # Release here caused the simulation to crash before
-                self.state.wait_aggregated_model_event.set()
+                self.state.aggregated_model_event.set()
 
             # Warning: these stops can cause a denegation of service attack
             except DecodingParamsError:

--- a/p2pfl/learning/aggregators/aggregator.py
+++ b/p2pfl/learning/aggregators/aggregator.py
@@ -18,7 +18,6 @@
 
 """Abstract aggregator."""
 
-import contextlib
 import threading
 from typing import List
 
@@ -77,7 +76,7 @@ class Aggregator:
             Exception: If the aggregation is running.
 
         """
-        if self._finish_aggregation_event.is_set(): 
+        if self._finish_aggregation_event.is_set():
             self.__train_set = nodes_to_aggregate
             self._finish_aggregation_event.clear()
         else:
@@ -85,7 +84,7 @@ class Aggregator:
 
     def clear(self) -> None:
         """Clear the aggregation (remove trainset and release locks)."""
-        with self.__agg_lock: 
+        with self.__agg_lock:
             self.__train_set = []
             self.__models = []
             self._finish_aggregation_event.set()
@@ -186,9 +185,9 @@ class Aggregator:
         # Check that the aggregation is finished
         missing_models = self.get_missing_models()
         # Check if aggregation has timed out or event has been set correctly
-        if not event_set: 
+        if not event_set:
             logger.info(self.node_name, f"⏳ Aggregation wait timed out. Missing models: {missing_models}")
-        else: 
+        else:
             if len(missing_models) > 0:
                 logger.info(
                     self.node_name,
@@ -196,24 +195,24 @@ class Aggregator:
                 )
             else:
                 logger.info(self.node_name, "🧠 Aggregating models.")
-        
+
         # Notify node
         return self.aggregate(self.__models)
 
-    def get_missing_models(self) -> set: 
+    def get_missing_models(self) -> set:
         """
         Obtain missing models for the aggregation.
 
-        Return:
-            A set of missing models. 
-        """
+        Returns:
+            A set of missing models.
 
+        """
         agg_models = []
         for m in self.__models:
             agg_models += m.get_contributors()
         missing_models = set(self.__train_set) - set(agg_models)
         return missing_models
-    
+
     def get_partial_aggregation(self, except_nodes: List[str]) -> P2PFLModel:
         """
         Obtain a partial aggregation.

--- a/p2pfl/learning/aggregators/aggregator.py
+++ b/p2pfl/learning/aggregators/aggregator.py
@@ -53,7 +53,8 @@ class Aggregator:
 
         # Locks
         self.__agg_lock = threading.Lock()
-        self._finish_aggregation_lock = threading.Lock()
+        self._finish_aggregation_event = threading.Event()
+        self._finish_aggregation_event.set()
 
     def aggregate(self, models: List[P2PFLModel]) -> P2PFLModel:
         """
@@ -76,20 +77,18 @@ class Aggregator:
             Exception: If the aggregation is running.
 
         """
-        if not self._finish_aggregation_lock.locked():
+        if self._finish_aggregation_event.is_set(): 
             self.__train_set = nodes_to_aggregate
-            self._finish_aggregation_lock.acquire(timeout=Settings.AGGREGATION_TIMEOUT)
+            self._finish_aggregation_event.clear()
         else:
             raise Exception("It is not possible to set nodes to aggregate when the aggregation is running.")
 
     def clear(self) -> None:
         """Clear the aggregation (remove trainset and release locks)."""
-        self.__agg_lock.acquire()
-        self.__train_set = []
-        self.__models = []
-        with contextlib.suppress(Exception):
-            self._finish_aggregation_lock.release()
-        self.__agg_lock.release()
+        with self.__agg_lock: 
+            self.__train_set = []
+            self.__models = []
+            self._finish_aggregation_event.set()
 
     def get_aggregated_models(self) -> List[str]:
         """
@@ -146,9 +145,9 @@ class Aggregator:
 
                     # Check if all models were added
                     if len(self.get_aggregated_models()) >= len(self.__train_set):
-                        self._finish_aggregation_lock.release()
+                        self._finish_aggregation_event.set()
 
-                    # Unloock and Return
+                    # Unlock and Return
                     self.__agg_lock.release()
                     return self.get_aggregated_models()
                 else:
@@ -183,26 +182,38 @@ class Aggregator:
 
         """
         # Wait for aggregation to finish (then release the lock again)
-        self._finish_aggregation_lock.acquire(timeout=timeout)
-        with contextlib.suppress(Exception):
-            self._finish_aggregation_lock.release()
-
+        event_set = self._finish_aggregation_event.wait(timeout=timeout)
         # Check that the aggregation is finished
+        missing_models = self.get_missing_models()
+        # Check if aggregation has timed out or event has been set correctly
+        if not event_set: 
+            logger.info(self.node_name, f"⏳ Aggregation wait timed out. Missing models: {missing_models}")
+        else: 
+            if len(missing_models) > 0:
+                logger.info(
+                    self.node_name,
+                    f"❌ Aggregation event set, but missing models:  {missing_models}",
+                )
+            else:
+                logger.info(self.node_name, "🧠 Aggregating models.")
+        
+        # Notify node
+        return self.aggregate(self.__models)
+
+    def get_missing_models(self) -> set: 
+        """
+        Obtain missing models for the aggregation.
+
+        Return:
+            A set of missing models. 
+        """
+
         agg_models = []
         for m in self.__models:
             agg_models += m.get_contributors()
         missing_models = set(self.__train_set) - set(agg_models)
-        if len(missing_models) > 0:
-            logger.info(
-                self.node_name,
-                f"❌ Aggregating models, timeout reached. Missing models: {missing_models}",
-            )
-        else:
-            logger.info(self.node_name, "🧠 Aggregating models.")
-
-        # Notify node
-        return self.aggregate(self.__models)
-
+        return missing_models
+    
     def get_partial_aggregation(self, except_nodes: List[str]) -> P2PFLModel:
         """
         Obtain a partial aggregation.

--- a/p2pfl/node_state.py
+++ b/p2pfl/node_state.py
@@ -77,7 +77,9 @@ class NodeState:
         self.wait_votes_ready_lock = threading.Lock()
         self.model_initialized_lock = threading.Lock()
         self.model_initialized_lock.acquire()
-        self.wait_aggregated_model_lock = threading.Lock()
+        # initally set the event, gets clearend in wait_agg_models_stage, wait is called after
+        self.wait_aggregated_model_event = threading.Event()
+        self.wait_aggregated_model_event.set()
 
         # puede quedar guay el privatizar todos los locks y meter métodos que al mismo tiempo seteen un estado (string)
 

--- a/p2pfl/node_state.py
+++ b/p2pfl/node_state.py
@@ -77,9 +77,8 @@ class NodeState:
         self.wait_votes_ready_lock = threading.Lock()
         self.model_initialized_lock = threading.Lock()
         self.model_initialized_lock.acquire()
-        # initally set the event, gets clearend in wait_agg_models_stage, wait is called after
-        self.wait_aggregated_model_event = threading.Event()
-        self.wait_aggregated_model_event.set()
+        self.aggregated_model_event = threading.Event()
+        self.aggregated_model_event.set()
 
         # puede quedar guay el privatizar todos los locks y meter métodos que al mismo tiempo seteen un estado (string)
 

--- a/p2pfl/stages/base_node/vote_train_set_stage.py
+++ b/p2pfl/stages/base_node/vote_train_set_stage.py
@@ -68,10 +68,6 @@ class VoteTrainSetStage(Stage):
             if state.addr in state.train_set:
                 return StageFactory.get_stage("TrainStage")
             else:
-                # Set lock aquire removed, since using threading.Event instead of threading.Lock theres no need to
-                # aquire a lock before proceeding to WaitAggregatedModelsStage
-                # In the original code it was intended to block the node until the agg model was received/timeout,
-                # with the change to event this sync happens in WaitAggregatedModlelsStage
                 logger.debug(state.addr, "Node not in train set. Proceeding to WaitAggregatedModelsStage.")
                 return StageFactory.get_stage("WaitAggregatedModelsStage")
         except EarlyStopException:

--- a/p2pfl/stages/base_node/vote_train_set_stage.py
+++ b/p2pfl/stages/base_node/vote_train_set_stage.py
@@ -68,8 +68,14 @@ class VoteTrainSetStage(Stage):
             if state.addr in state.train_set:
                 return StageFactory.get_stage("TrainStage")
             else:
-                # Set state as waiting for aggregated model
-                state.wait_aggregated_model_lock.acquire(timeout=Settings.AGGREGATION_TIMEOUT)
+                # Set lock aquire removed, since using threading.Event instead of threading.Lock theres no need to 
+                # aquire a lock before proceeding to WaitAggregatedModelsStage
+                # In the original code it was intended to block the node until the agg model was received/timeout,
+                # with the change to event this sync happens in WaitAggregatedModlelsStage
+                logger.debug(
+                    state.addr,
+                    "Node not in train set. Proceeding to WaitAggregatedModelsStage."
+                )
                 return StageFactory.get_stage("WaitAggregatedModelsStage")
         except EarlyStopException:
             return None

--- a/p2pfl/stages/base_node/vote_train_set_stage.py
+++ b/p2pfl/stages/base_node/vote_train_set_stage.py
@@ -68,14 +68,11 @@ class VoteTrainSetStage(Stage):
             if state.addr in state.train_set:
                 return StageFactory.get_stage("TrainStage")
             else:
-                # Set lock aquire removed, since using threading.Event instead of threading.Lock theres no need to 
+                # Set lock aquire removed, since using threading.Event instead of threading.Lock theres no need to
                 # aquire a lock before proceeding to WaitAggregatedModelsStage
                 # In the original code it was intended to block the node until the agg model was received/timeout,
                 # with the change to event this sync happens in WaitAggregatedModlelsStage
-                logger.debug(
-                    state.addr,
-                    "Node not in train set. Proceeding to WaitAggregatedModelsStage."
-                )
+                logger.debug(state.addr, "Node not in train set. Proceeding to WaitAggregatedModelsStage.")
                 return StageFactory.get_stage("WaitAggregatedModelsStage")
         except EarlyStopException:
             return None

--- a/p2pfl/stages/base_node/wait_agg_models_stage.py
+++ b/p2pfl/stages/base_node/wait_agg_models_stage.py
@@ -44,10 +44,10 @@ class WaitAggregatedModelsStage(Stage):
         if state is None or communication_protocol is None:
             raise Exception("Invalid parameters on WaitAggregatedModelsStage.")
         # clear here instead of aquiring in vote_train_set_stage
-        state.wait_aggregated_model_event.clear()
+        state.aggregated_model_event.clear()
         logger.info(state.addr, "⏳ Waiting aggregation.")
         # Wait for aggregation to finish, if time over timeout log a warning message
-        event_set = state.wait_aggregated_model_event.wait(timeout=Settings.AGGREGATION_TIMEOUT)
+        event_set = state.aggregated_model_event.wait(timeout=Settings.AGGREGATION_TIMEOUT)
 
         if event_set:
             # The event was set before the timeout

--- a/p2pfl/stages/base_node/wait_agg_models_stage.py
+++ b/p2pfl/stages/base_node/wait_agg_models_stage.py
@@ -46,9 +46,10 @@ class WaitAggregatedModelsStage(Stage):
             raise Exception("Invalid parameters on WaitAggregatedModelsStage.")
         # clear here instead of aquiring in vote_train_set_stage
         state.wait_aggregated_model_event.clear()
-        event_set = state.wait_aggregated_model_event.wait(timeout=Settings.AGGREGATION_TIMEOUT)
-        # Wait for aggregation to finish, if time over timeout log a warning message
         logger.info(state.addr, "⏳ Waiting aggregation.")
+        # Wait for aggregation to finish, if time over timeout log a warning message
+        event_set = state.wait_aggregated_model_event.wait(timeout=Settings.AGGREGATION_TIMEOUT)
+        
         if event_set:
             # The event was set before the timeout
             logger.info(state.addr, "✅ Aggregation event received.")

--- a/p2pfl/stages/base_node/wait_agg_models_stage.py
+++ b/p2pfl/stages/base_node/wait_agg_models_stage.py
@@ -17,7 +17,6 @@
 #
 """Wait aggregated models stage."""
 
-import contextlib
 from typing import Optional, Type, Union
 
 from p2pfl.communication.commands.message.models_ready_command import ModelsReadyCommand
@@ -49,7 +48,7 @@ class WaitAggregatedModelsStage(Stage):
         logger.info(state.addr, "⏳ Waiting aggregation.")
         # Wait for aggregation to finish, if time over timeout log a warning message
         event_set = state.wait_aggregated_model_event.wait(timeout=Settings.AGGREGATION_TIMEOUT)
-        
+
         if event_set:
             # The event was set before the timeout
             logger.info(state.addr, "✅ Aggregation event received.")

--- a/test/learning/aggregator_test.py
+++ b/test/learning/aggregator_test.py
@@ -109,7 +109,7 @@ def test_avg_complex():
     assert set(res.get_contributors()) == {"1", "2", "3"}
 
 
-def test_aggregator_lifecicle():
+def test_aggregator_lifecycle():
     """Test the aggregator lock."""
     aggregator = FedAvg()
     aggregator.set_nodes_to_aggregate(["node1", "node2", "node3"])
@@ -122,8 +122,8 @@ def test_aggregator_lifecicle():
     model1 = LightningModel(MLP(), num_samples=1, contributors=["node1"])
     aggregator.add_model(model1)
 
-    # Ensure that the lock is not released
-    assert aggregator._finish_aggregation_lock.locked()
+    # Ensure that the previous lock, now an event is cleared (equivalent to locked)
+    assert not aggregator._finish_aggregation_event.is_set()
 
     # Check if the model was added
     assert aggregator.get_aggregated_models() == ["node1"]


### PR DESCRIPTION
## Description

Im adressing issue #37 with this PR. When running the simulation with 20 BERT nodes and 4 learners (TRAIN_SET_SIZE) ive I experienced the unlock of an already released lock in full_model_command.py at line 77. 

Fixes # (issue)
#37
 
## Changes
In the aggreator.py class ive changed the wait_aggregated_model Lock to an event to prevent desync during aggregation. 
This has also been done with the unlocking lock causing the issue. mentioned above. Also ive outsourced the get missing models to a seperated function to improve readibility 

## How can we see the results or reproduce them?
[p2pfl_lock_as_Event (1).log](https://github.com/user-attachments/files/17327981/p2pfl_lock_as_Event.1.log) This is the BERT training run without the change. Im training BERT on MNLI, can also be seen in my private repo. Pedro has been invited to this already.
After the fix it runs through without any issues or changed business logic. A log confirming this is attached. 
[first_full_run.log](https://github.com/user-attachments/files/17328010/first_full_run.log

## How Has This Been Tested?

- [x] End-to-end test running BERT training on 20 nodes with 4 trainer nodes


## How do you want others to review your code?
- Entire diff

