### PR TITLE
making-test-collection-work-without-extras

### DIFF
--- a/p2pfl/examples/mnist/model/mlp_generator_factory.py
+++ b/p2pfl/examples/mnist/model/mlp_generator_factory.py
@@ -1,0 +1,53 @@
+#
+# This file is part of the federated_learning_p2p (p2pfl) distribution
+# (see https://github.com/pguijas/p2pfl).
+# Copyright (c) 2025 Pedro Guijas Bravo.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, version 3.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+"""Factory of functions to create MLPs for MNIST."""
+
+import contextlib
+from enum import Enum, auto
+from typing import Callable
+
+with contextlib.suppress(ImportError):
+    from p2pfl.examples.mnist.model.mlp_tensorflow import model_build_fn as model_build_fn_tensorflow
+
+with contextlib.suppress(ImportError):
+    from p2pfl.examples.mnist.model.mlp_pytorch import model_build_fn as model_build_fn_pytorch
+
+with contextlib.suppress(ImportError):
+    from p2pfl.examples.mnist.model.mlp_flax import model_build_fn as model_build_fn_flax
+
+
+class ModelType(Enum):
+    """Enum for the supported model types."""
+
+    TENSORFLOW = auto()
+    PYTORCH = auto()
+    FLAX = auto()
+
+
+def get_model_builder(model_type: ModelType) -> Callable:
+    """Get the model builder function for the given model type."""
+    match model_type:
+        case ModelType.TENSORFLOW:
+            return model_build_fn_tensorflow
+        case ModelType.PYTORCH:
+            return model_build_fn_pytorch
+        case ModelType.FLAX:
+            return model_build_fn_flax
+        case _:
+            raise ValueError("Invalid model type")

--- a/test/learning/frameworks_test.py
+++ b/test/learning/frameworks_test.py
@@ -24,6 +24,7 @@ import numpy as np
 import pytest
 from datasets import DatasetDict, load_dataset  # type: ignore
 
+from p2pfl.examples.mnist.model.mlp_generator_factory import ModelType, get_model_builder
 from p2pfl.experiment import Experiment
 from p2pfl.learning.dataset.p2pfl_dataset import P2PFLDataset
 from p2pfl.learning.frameworks.exceptions import ModelNotMatchingError
@@ -313,8 +314,8 @@ def __test_flax_export_strategy():
     assert y.shape == (1,)
 
 
-@pytest.mark.parametrize("build_model_fn", [model_build_fn_torch, model_build_fn_tensorflow])  # TODO: Flax
-def test_learner_train(build_model_fn):
+@pytest.mark.parametrize("model_type", [ModelType.PYTORCH, ModelType.TENSORFLOW])  # TODO: Flax
+def test_learner_train(model_type):
     """Test the training and testing of the learner."""
     # Dataset
     dataset = P2PFLDataset(
@@ -327,6 +328,7 @@ def test_learner_train(build_model_fn):
     )
 
     # Create the model
+    build_model_fn = get_model_builder(model_type)
     p2pfl_model = build_model_fn()
 
     # Dont care about the seed

--- a/test/node_test.py
+++ b/test/node_test.py
@@ -20,6 +20,7 @@
 import contextlib  # noqa: E402, I001
 import time  # noqa: E402
 import pytest  # noqa: E402
+from p2pfl.examples.mnist.model.mlp_generator_factory import ModelType, get_model_builder
 from p2pfl.learning.dataset.p2pfl_dataset import P2PFLDataset  # noqa: E402
 from p2pfl.learning.dataset.partition_strategies import RandomIIDPartitionStrategy  # noqa: E402
 from p2pfl.learning.frameworks import Framework
@@ -82,9 +83,10 @@ def log_test_start_and_end(request):
 #   stochastic process, so is not fully deterministic!.
 #
 @pytest.mark.parametrize("x", [(2, 2), (6, 3)])
-@pytest.mark.parametrize("model_build_fn", [model_build_fn_pytorch, model_build_fn_tensorflow])
-def test_convergence(x, model_build_fn):
+@pytest.mark.parametrize("model_type", [ModelType.PYTORCH, ModelType.TENSORFLOW])  # TODO: Flax
+def test_convergence(x, model_type):
     """Test convergence (on learning) of two nodes."""
+    model_build_fn = get_model_builder(model_type)
     n, r = x
 
     Settings.general.SEED = 777
@@ -221,14 +223,15 @@ def _test_node_down_on_learning(n):
 #####
 
 
-@pytest.mark.parametrize("build_model_fn", [model_build_fn_pytorch, model_build_fn_tensorflow])
-def test_framework_node(build_model_fn):
+@pytest.mark.parametrize("model_type", [ModelType.PYTORCH, ModelType.TENSORFLOW])  # TODO: Flax
+def test_framework_node(model_type):
     """Test a TensorFlow node."""
     # Data
     data = P2PFLDataset.from_huggingface("p2pfl/MNIST")
     partitions = data.generate_partitions(400, RandomIIDPartitionStrategy)
 
     # Create the model
+    build_model_fn = get_model_builder(model_type)
     p2pfl_model = build_model_fn()
 
     # Nodes


### PR DESCRIPTION
## Description
The test collecting wasnt working because some functions that depends on non mandatory libraries where being inserted in pytests.mark.fixture.
I used the ocation to create a factory that create a model_constructor for tensorflow, pytorch and flax based on an Enum.