### PR TITLE
fix: downgraded Click to 8.1.8 to maintain compatibility with Typer

### DIFF
--- a/p2pfl/management/cli.py
+++ b/p2pfl/management/cli.py
@@ -19,6 +19,7 @@
 """CLI for the p2pfl platform."""
 
 import os
+import sys
 from glob import glob
 from typing import Annotated, TypedDict
 
@@ -58,6 +59,9 @@ logo = r"""[italic]
 ####
 # CLI Commands
 ####
+
+if len(sys.argv) > 1 and sys.argv[1] == "help":
+    sys.argv[1] = "--help"
 
 console = Console()
 app = typer.Typer(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "tqdm>=4.67.0,<5",
     "protobuf>=5.29.1",
     "pyyaml>=6.0.2,<7",
+    "click==8.1.8",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -310,14 +310,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.2.1"
+version = "8.1.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/60/6c/8ca2efa64cf75a977a0d7fac081354553ebe483345c734fb6b6515d96bbc/click-8.2.1.tar.gz", hash = "sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202", size = 286342, upload-time = "2025-05-20T23:19:49.832Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593, upload-time = "2024-12-21T18:38:44.339Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/85/32/10bb5764d90a8eee674e9dc6f4db6a0ab47c8c4d0d83c27f7c39ac415a4d/click-8.2.1-py3-none-any.whl", hash = "sha256:61a3265b914e850b85317d0b3109c7f8cd35a670f963866005d6ef1d5175a12b", size = 102215, upload-time = "2025-05-20T23:19:47.796Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/d4/7ebdbd03970677812aac39c869717059dbb71a4cfc033ca6e5221787892c/click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2", size = 98188, upload-time = "2024-12-21T18:38:41.666Z" },
 ]
 
 [[package]]
@@ -1908,6 +1908,7 @@ name = "p2pfl"
 version = "0.4.3"
 source = { editable = "." }
 dependencies = [
+    { name = "click" },
     { name = "datasets" },
     { name = "grpcio" },
     { name = "grpcio-tools" },
@@ -1963,6 +1964,7 @@ docs = [
 
 [package.metadata]
 requires-dist = [
+    { name = "click", specifier = "==8.1.8" },
     { name = "datasets", specifier = "==2.15.0" },
     { name = "flax", marker = "extra == 'flax'", specifier = ">=0.10.0,<0.11" },
     { name = "grpcio", specifier = ">=1.62.0,<2" },


### PR DESCRIPTION
### Summary

- Added alias to make `p2pfl help` equivalent to `--help`
- Fixed a crash on `p2pfl --help` caused by an incompatibility between `Typer` and `Click>=8.2.0`

### Fix

- Downgraded Click to `8.1.8` to maintain compatibility with Typer